### PR TITLE
feat: install shell completions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -33,8 +33,10 @@ jobs:
     - name: Set environment variables for latest release
       run: |
         # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
-        echo "TAG_NAME=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tag_name')" >> $GITHUB_ENV
-        echo "TARBALL_URL=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tarball_url')" >> $GITHUB_ENV
+        TAG_NAME=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tag_name')
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+        # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
+        echo "TARBALL_URL=https://github.com/defang-io/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> $GITHUB_ENV
 
     - name: Compute SHA256 checksum
       run: |

--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -13,9 +13,15 @@ class Defang < Formula
     Dir.chdir "src" do
       system "go", "build", "-o", bin/"defang", *std_go_args(ldflags: "#{version_info} -s -w"), "./cmd/cli"
     end
+
+    # Install shell completions (using the binary we just built to generate them)
+    system "./src/bin/completions.sh", bin/"defang"
+    bash_completion.install "defang.bash" => "defang"
+    zsh_completion.install "defang.fish" => "_defang"
+    fish_completion.install "defang.zsh"
   end
 
   test do
-    system "false"
+    system bin/"defang", "version"
   end
 end

--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -17,8 +17,8 @@ class Defang < Formula
     # Install shell completions (using the binary we just built to generate them)
     system "./src/bin/completions.sh", bin/"defang"
     bash_completion.install "defang.bash" => "defang"
-    zsh_completion.install "defang.fish" => "_defang"
-    fish_completion.install "defang.zsh"
+    zsh_completion.install "defang.zsh" => "_defang"
+    fish_completion.install "defang.fish"
   end
 
   test do

--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -22,6 +22,6 @@ class Defang < Formula
   end
 
   test do
-    system bin/"defang", "version"
+    system bin/"defang", "--version"
   end
 end

--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -1,8 +1,8 @@
 class Defang < Formula
   desc "Command-line interface for the Defang Opinionated Platform"
   homepage "https://defang.io"
-  url "https://api.github.com/repos/defang-io/defang/tarball/v0.5.13"
-  sha256 "51cb6763b6754b5af1506c31872bf31c0cf33429dea51fa1221e0047835324b3"
+  url "https://github.com/defang-io/defang/archive/refs/tags/v0.5.13.tar.gz"
+  sha256 "efdf339856cbe367d4d675f25cfbebcff2e16b1774316cbf3384a91a27d297df"
   license "MIT"
   head "https://github.com/defang-io/defang.git", branch: "main"
 


### PR DESCRIPTION
ref https://github.com/defang-io/defang/issues/187

- [x] The current release (0.5.7) doesn't have the completion script, so can't merge until the next release.
- [x] FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs (url is https://api.github.com/repos/defang-io/defang/tarball/v0.5.7).
