### PR TITLE
Set -buildvcs=false to prevent possible brew install error

### DIFF
--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -11,7 +11,7 @@ class Defang < Formula
   def install
     version_info = "-X main.version=#{version}"
     Dir.chdir "src" do
-      system "go", "build", "-o", bin/"defang", *std_go_args(ldflags: "#{version_info} -s -w"), "./cmd/cli"
+      system "go", "build", "-o", bin/"defang", "-buildvcs=false", *std_go_args(ldflags: "#{version_info} -s -w"), "./cmd/cli"
     end
 
     # Install shell completions (using the binary we just built to generate them)


### PR DESCRIPTION
When Bjorn is doing brew update, he ends up with an error like below during the go build command:

```
error obtaining VCS status: exit status 128
    	Use -buildvcs=false to disable VCS stamping.
```

And the root cause is he had a `.git` folder in the `/tmp` folder, and the source tar was expanded in the `/tmp` folder, which results in go binary considered it is in a git repo, but the command trying to get the git repo info failed and results in installation failure. Since we are installing from a tar snapshot, it is safe to always set `-buildvcs=false` and avoid possible similar issues.

Ref:
[https://pkg.go.dev/cmd/go](https://pkg.go.dev/cmd/go#:~:text=buildmode%27%20for%20more.-,%2Dbuildvcs,-Whether%20to%20stamp)